### PR TITLE
Use JDK8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'temurin'
           cache: maven
       - name: Build with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vinted.kafka.connect.vespa</groupId>
     <artifactId>kafka-connect-vespa</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>kafka-connect-vespa</name>
     <description>The Vespa Sink Connector is used to write data from Kafka to a Vespa search engine.</description>
     <url>https://github.com/vinted/kafka-connect-vespa</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
         <kafka.version>2.8.2</kafka.version>
         <log4j.version>2.17.1</log4j.version>
         <slf4j.version>1.7.30</slf4j.version>

--- a/src/main/java/com/vinted/kafka/connect/vespa/converters/KeyConverter.java
+++ b/src/main/java/com/vinted/kafka/connect/vespa/converters/KeyConverter.java
@@ -14,7 +14,7 @@ public class KeyConverter {
             throw new DataException("Key is used as document id and can not be null.");
         }
 
-        if (String.valueOf(key).isBlank()) {
+        if (String.valueOf(key).isEmpty()) {
             throw new DataException("Key is used as document id and can not be empty.");
         }
 


### PR DESCRIPTION
Uses JDK8 instead of JDK11 for backward compatibility with older Kafka Connect versions.