### PR TITLE
Fix document type bug in document construction

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
         run: mvn package
       - uses: actions/upload-artifact@v3
         with:
-          name: kafka-connect-vespa-${{ steps.project.outputs.version }}
+          name: vinted-kafka-connect-vespa-${{ steps.project.outputs.version }}
           path: |
-            target/components/kafka-connect-vespa-${{ steps.project.outputs.version }}.jar
+            target/kafka-connect-vespa-${{ steps.project.outputs.version }}-jar-with-dependencies.jar
             target/components/packages/vinted-kafka-connect-vespa-${{ steps.project.outputs.version }}.zip

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ accessed and compared to a given string, for instance. An example use
 case is visiting a subset of documents. Defaults to topic name if not specified.
 
 - Type: string
-- Default: \"\"
+- Default: null
 - Importance: high
 
 `vespa.document.type`
 Document type as defined in services.xml and the schema. Defaults to topic name if not specified.
 
 - Type: string
-- Default: \"\"
+- Default: null
 - Importance: high
 
 `vespa.operational.mode`
@@ -174,7 +174,7 @@ message.
 
 `vespa.behavior.on.malformed.documents`
 How to handle records that Vespa rejects due to document malformation.
-Valid options are ignore', 'warn', and 'fail'.
+Valid options are `ignore`, `warn`, and `fail`.
 
 - Type: string
 - Default: FAIL

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vinted.kafka.connect.vespa</groupId>
     <artifactId>kafka-connect-vespa</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
     <name>kafka-connect-vespa</name>
     <description>The Vespa Sink Connector is used to write data from Kafka to a Vespa search engine.</description>
     <url>https://github.com/vinted/kafka-connect-vespa</url>

--- a/src/main/java/com/vinted/kafka/connect/vespa/VespaSinkConfig.java
+++ b/src/main/java/com/vinted/kafka/connect/vespa/VespaSinkConfig.java
@@ -68,13 +68,13 @@ public class VespaSinkConfig extends AbstractConfig {
             + "document selection, where id.namespace can be accessed and compared to a given string, for instance. "
             + "An example use case is visiting a subset of documents. Defaults to topic name if not specified.";
     private static final String NAMESPACE_DISPLAY = "Namespace";
-    private static final String NAMESPACE_DEFAULT = "";
+    private static final String NAMESPACE_DEFAULT = null;
 
     public static final String DOCUMENT_TYPE_CONFIG = "vespa.document.type";
     private static final String DOCUMENT_TYPE_DOC = "Document type as defined in services.xml and the schema. "
             + "Defaults to topic name if not specified";
     private static final String DOCUMENT_TYPE_DISPLAY = "Document type";
-    private static final String DOCUMENT_TYPE_DEFAULT = "";
+    private static final String DOCUMENT_TYPE_DEFAULT = null;
 
     public static final String OPERATIONAL_MODE_CONFIG = "vespa.operational.mode";
     private static final String OPERATIONAL_MODE_DOC = "The operational mode of the connector. Valid options are "
@@ -116,7 +116,7 @@ public class VespaSinkConfig extends AbstractConfig {
 
     public static final String BEHAVIOR_ON_MALFORMED_DOCS_CONFIG = "vespa.behavior.on.malformed.documents";
     private static final String BEHAVIOR_ON_MALFORMED_DOCS_DOC = "How to handle records that Vespa rejects due to "
-            + "document malformation. Valid options are ignore', 'warn', and 'fail'.";
+            + "document malformation. Valid options are `ignore`, `warn`, and `fail`.";
     private static final String BEHAVIOR_ON_MALFORMED_DOCS_DISPLAY = "Behavior on malformed documents";
     private static final BehaviorOnMalformedDoc BEHAVIOR_ON_MALFORMED_DOCS_DEFAULT = BehaviorOnMalformedDoc.FAIL;
 
@@ -205,6 +205,7 @@ public class VespaSinkConfig extends AbstractConfig {
                         NAMESPACE_CONFIG,
                         ConfigDef.Type.STRING,
                         NAMESPACE_DEFAULT,
+                        ConfigDef.NonEmptyStringWithoutControlChars.nonEmptyStringWithoutControlChars(),
                         ConfigDef.Importance.HIGH,
                         NAMESPACE_DOC,
                         CONNECTOR_GROUP,
@@ -215,6 +216,7 @@ public class VespaSinkConfig extends AbstractConfig {
                         DOCUMENT_TYPE_CONFIG,
                         ConfigDef.Type.STRING,
                         DOCUMENT_TYPE_DEFAULT,
+                        ConfigDef.NonEmptyStringWithoutControlChars.nonEmptyStringWithoutControlChars(),
                         ConfigDef.Importance.HIGH,
                         DOCUMENT_TYPE_DOC,
                         CONNECTOR_GROUP,

--- a/src/main/java/com/vinted/kafka/connect/vespa/feeders/VespaUpsertFeeder.java
+++ b/src/main/java/com/vinted/kafka/connect/vespa/feeders/VespaUpsertFeeder.java
@@ -89,11 +89,11 @@ public class VespaUpsertFeeder implements VespaFeeder {
     }
 
     private String getNamespace(SinkRecord record) {
-        return config.namespace.isEmpty() ? record.topic() : config.namespace;
+        return config.namespace == null ? record.topic() : config.namespace;
     }
 
     private String getDocumentType(SinkRecord record) {
-        return config.namespace.isEmpty() ? record.topic() : config.documentType;
+        return config.documentType == null ? record.topic() : config.documentType;
     }
 
     private static class Operation {


### PR DESCRIPTION
## Type of PR

- [x] Documentation changes
- [x] Code changes
- [x] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

When constructing a document type, it would check for blank namespace, not for blank document type. I also changed connector configs to default to null meaning that they could be validated when the user inputs something.

## Testing

- Did you add testing to account for any new or changed work? ✔️ 

## Review notes

## Issues Closed or Referenced

N/A
