### PR TITLE
Fetch connector version correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,5 +241,12 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
     </build>
 </project>

--- a/src/main/assembly/package.xml
+++ b/src/main/assembly/package.xml
@@ -1,0 +1,44 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2
+          http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <!-- Assembles a packaged version targeting OS installation. -->
+    <id>package</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory>share/doc/kafka-connect-vespa/</outputDirectory>
+            <includes>
+                <include>README*</include>
+                <include>LICENSE*</include>
+                <include>NOTICE*</include>
+                <include>licenses.html</include>
+                <include>licenses/</include>
+                <include>notices/</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/config</directory>
+            <outputDirectory>etc/kafka-connect-vespa</outputDirectory>
+            <includes>
+                <include>*</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>share/java/kafka-connect-vespa</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <excludes>
+                <!-- Exclude these jars during packaging.-->
+                <exclude>org.apache.kafka:connect-api</exclude>
+                <exclude>org.apache.kafka:connect-json</exclude>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/src/main/java/com/vinted/kafka/connect/vespa/VespaSinkConnector.java
+++ b/src/main/java/com/vinted/kafka/connect/vespa/VespaSinkConnector.java
@@ -1,6 +1,5 @@
 package com.vinted.kafka.connect.vespa;
 
-import com.github.jcustenborder.kafka.connect.utils.VersionUtil;
 import com.github.jcustenborder.kafka.connect.utils.config.Description;
 import com.github.jcustenborder.kafka.connect.utils.config.DocumentationImportant;
 import com.github.jcustenborder.kafka.connect.utils.config.DocumentationNote;
@@ -58,6 +57,6 @@ public class VespaSinkConnector extends SinkConnector {
 
     @Override
     public String version() {
-        return VersionUtil.version(this.getClass());
+        return VespaSinkConnectorVersion.getVersion();
     }
 }

--- a/src/main/java/com/vinted/kafka/connect/vespa/VespaSinkConnectorVersion.java
+++ b/src/main/java/com/vinted/kafka/connect/vespa/VespaSinkConnectorVersion.java
@@ -1,0 +1,31 @@
+package com.vinted.kafka.connect.vespa;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+public class VespaSinkConnectorVersion {
+    private static final Logger log = LoggerFactory.getLogger(VespaSinkConnectorVersion.class);
+    private static String version = "unknown";
+
+    private static final String VERSION_FILE = "/kafka-connect-vespa-version.properties";
+
+    static {
+        try {
+            Properties props = new Properties();
+            try (InputStream versionFileStream = VespaSinkConnectorVersion.class.getResourceAsStream(VERSION_FILE)) {
+                props.load(versionFileStream);
+                version = props.getProperty("version", version).trim();
+            }
+        } catch (Exception e) {
+            log.warn("Error while loading version:", e);
+        }
+    }
+
+    public static String getVersion() {
+        return version;
+    }
+}

--- a/src/main/resources/kafka-connect-vespa-version.properties
+++ b/src/main/resources/kafka-connect-vespa-version.properties
@@ -1,0 +1,15 @@
+##
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+version=${project.version}


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Currently, the connector version is shown as `0.0.0.0`.
```json
[
  {
    "class": "com.vinted.kafka.connect.vespa.VespaSinkConnector",
    "type": "sink",
    "version": "0.0.0.0"
  }
]
```

After the change, it is correctly taken from pom.xml file.
```json
[
  {
    "class": "com.vinted.kafka.connect.vespa.VespaSinkConnector",
    "type": "sink",
    "version": "1.0.5-SNAPSHOT"
  }
]
```

## Testing

- Did you add testing to account for any new or changed work?

## Review notes

## Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)
