### PR TITLE
Fix/send poisonous messages to dlq

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ This connector has not yet been published to Confluent Hub. To install it, downl
 install it using `confluent-hub` command line tool.
 
 ```sh
-wget https://github.com/vinted/kafka-connect-vespa/releases/download/v1.0.6/vinted-kafka-connect-vespa-1.0.6-SNAPSHOT.zip -O /tmp/vinted-kafka-connect-vespa-1.0.6-SNAPSHOT.zip -q
+wget https://github.com/vinted/kafka-connect-vespa/releases/download/v1.0.7/vinted-kafka-connect-vespa-1.0.7-SNAPSHOT.zip -O /tmp/vinted-kafka-connect-vespa-1.0.7-SNAPSHOT.zip -q
 ```
 
 ```sh
-confluent-hub install --no-prompt /tmp/vinted-kafka-connect-vespa-1.0.6-SNAPSHOT.zip
+confluent-hub install --no-prompt /tmp/vinted-kafka-connect-vespa-1.0.7-SNAPSHOT.zip
 ```
 
 ### Operational modes

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.vinted.kafka.connect.vespa</groupId>
     <artifactId>kafka-connect-vespa</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <name>kafka-connect-vespa</name>
     <description>The Vespa Sink Connector is used to write data from Kafka to a Vespa search engine.</description>
     <url>https://github.com/vinted/kafka-connect-vespa</url>

--- a/src/main/java/com/vinted/kafka/connect/vespa/feeders/VespaFeederHandler.java
+++ b/src/main/java/com/vinted/kafka/connect/vespa/feeders/VespaFeederHandler.java
@@ -100,7 +100,10 @@ public class VespaFeederHandler {
                 .findFirst()
                 .orElse(throwable);
 
-        return rootCause.toString().toLowerCase().contains("status 400")
+        String rootCauseString = rootCause.toString().toLowerCase();
+
+        return rootCauseString.contains("status 400")
+                || rootCauseString.contains("string field value contains illegal code point")
                 || rootCause instanceof OperationParseException
                 || rootCause instanceof JsonParseException;
     }


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Messages with illegal characters stop ingestion. Handle them as poisonous messages, send them to the dead letter queue, and continue indexing.

## Testing

- Did you add testing to account for any new or changed work?

N/A

## Review notes

## Issues Closed or Referenced
