### PR TITLE
Do not treat result parse exception as malformed

### DIFF
--- a/src/main/java/com/vinted/kafka/connect/vespa/feeders/VespaFeederHandler.java
+++ b/src/main/java/com/vinted/kafka/connect/vespa/feeders/VespaFeederHandler.java
@@ -3,6 +3,7 @@ package com.vinted.kafka.connect.vespa.feeders;
 import ai.vespa.feed.client.DocumentId;
 import ai.vespa.feed.client.OperationParseException;
 import ai.vespa.feed.client.Result;
+import ai.vespa.feed.client.ResultParseException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.vinted.kafka.connect.vespa.VespaReporter;
 import com.vinted.kafka.connect.vespa.VespaSinkConfig;
@@ -108,10 +109,11 @@ public class VespaFeederHandler {
 
         String rootCauseString = rootCause.toString().toLowerCase();
 
-        return rootCauseString.contains("status 400")
+        return !(rootCause instanceof ResultParseException)
+                && (rootCauseString.contains("status 400")
                 || rootCauseString.contains("string field value contains illegal code point")
                 || rootCause instanceof OperationParseException
-                || rootCause instanceof JsonParseException;
+                || rootCause instanceof JsonParseException);
     }
 
     private static Result ignoredResult() {


### PR DESCRIPTION
## Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

When a timeout happens, the feed client would raise a `ResultParseException` which inherits `JsonParseException` and this falls under the `isMalformed` condition. This can happen during upgrades or timeouts and it's not right to ignore such messages and skip them

## Testing

- Did you add testing to account for any new or changed work?

## Review notes

## Issues Closed or Referenced

- Closes #<issue number> (this will automatically close the issue when the PR closes)
- References #<issue number> (this references the issue but does not close with PR)
